### PR TITLE
always go to pawn height when it is promotion

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -103,7 +103,7 @@ def handleStockfishMove():
         promotion = chess_logic.pieces[best_move[-1]]
         best_move = best_move[:-1]
         best_move = best_move[:len(best_move)//2]
-        cr.move_taken(best_move, piece)
+        cr.move_taken(best_move, "p")
         cr.reset()
         socket_io.emit("promotion", promotion)
     else:


### PR DESCRIPTION
It is always a pawn that will be promoted. Changed so that the robot always removes a piece in pawn height when it removes the pawn from the board for promotion.